### PR TITLE
Add info about each PGS to the output

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The script will output a tsv file containing the PubmedIDs and the corresponding
 The script can be run using the following command:
 
 ```
-python3 map_pmids.py --input test_input.csv --output test_output.tsv
+python3 map_pmids.py --pmid-file test_input.csv --outfile test_output.tsv
 ```
 
 Once you have the mapping output file, you can generate a report about the matches.

--- a/map_pmids.py
+++ b/map_pmids.py
@@ -43,10 +43,16 @@ for pgs_id in progressbar.progressbar(pgs_ids):
     pgs_response = requests.get(pgs_url.format(pgs_id=pgs_id))
     # Note that some PGS have more than one entry in the samples_variants list.
     # assert len(pgs_response.json()["samples_variants"]) == 1
+    if len(pgs_response.json()["samples_variants"]) > 1:
+        ancestry_broad = "MULTIPLE"
+    elif len(pgs_response.json()["samples_variants"]) == 0:
+        ancestry_broad = "UNKNOWN"
+    else:
+        ancestry_broad = pgs_response.json()["samples_variants"][0]["ancestry_broad"]
     results_list.append({
             "pgs_id": pgs_id,
             "trait_reported": pgs_response.json()["trait_reported"],
-            # "ancestry_broad": pgs_response.json()["samples_variants"][0]["ancestry_broad"],
+            "ancestry_broad": ancestry_broad,
     })
 
 df_scores = pd.DataFrame(results_list)

--- a/mapping_report.qmd
+++ b/mapping_report.qmd
@@ -64,6 +64,37 @@ mapping_results %>%
     kable()
 ```
 
+## PGS info
+
+```{r}
+mapping_results %>%
+    select(pgs_id, trait_reported, ancestry_broad) %>%
+    distinct() %>%
+    kable()
+```
+
+
+## Number of unique PGS by ancestry
+```{r}
+mapping_results %>%
+    select(pgs_id, ancestry_broad) %>%
+    distinct() %>%
+    group_by(ancestry_broad) %>%
+    count() %>%
+    kable()
+```
+
+## Number of unique pubs by ancestry
+
+```{r}
+mapping_results %>%
+    select(pm_id, ancestry_broad) %>%
+    distinct() %>%
+    group_by(ancestry_broad) %>%
+    count() %>%
+    kable()
+```
+
 # Full mapping results
 
 ```{r}

--- a/mapping_report.qmd
+++ b/mapping_report.qmd
@@ -43,6 +43,27 @@ mapping_results %>%
     kable()
 ```
 
+## Number of unique PGS by trait
+```{r}
+mapping_results %>%
+    select(pgs_id, trait_reported) %>%
+    distinct() %>%
+    group_by(trait_reported) %>%
+    count() %>%
+    kable()
+```
+
+## Number of unique pubs by trait
+
+```{r}
+mapping_results %>%
+    select(pm_id, trait_reported) %>%
+    distinct() %>%
+    group_by(trait_reported) %>%
+    count() %>%
+    kable()
+```
+
 # Full mapping results
 
 ```{r}

--- a/test_output.tsv
+++ b/test_output.tsv
@@ -1,5 +1,5 @@
-pm_id	pgp_id	pgs_type	pgs_id
-37945903	PGP000488	development	PGS003765
-37945903	PGP000488	development	PGS003766
-37945903	PGP000488	evaluation	PGS003765
-37945903	PGP000488	evaluation	PGS003766
+pm_id	pgp_id	pgs_type	pgs_id	trait_reported	ancestry_broad
+37945903	PGP000488	development	PGS003765	Prostate cancer	European, African unspecified, East Asian, Hispanic or Latin American
+37945903	PGP000488	development	PGS003766	Prostate cancer	European, African unspecified, East Asian, Hispanic or Latin American
+37945903	PGP000488	evaluation	PGS003765	Prostate cancer	European, African unspecified, East Asian, Hispanic or Latin American
+37945903	PGP000488	evaluation	PGS003766	Prostate cancer	European, African unspecified, East Asian, Hispanic or Latin American


### PR DESCRIPTION
Include the following info for each PGS:
- trait
- ancestry (note that when the PGS catalog returns multiple "samples_variants" for a given PGS, the code sets it to "MULTIPLE"; when it returns 0 samples_variants, the code sets it to "UNKNOWN")

Closes #2 