### PR TITLE
Fix bug in total variants when there are no matches on a chromosome

### DIFF
--- a/pgs_variant_overlap.wdl
+++ b/pgs_variant_overlap.wdl
@@ -72,7 +72,7 @@ task create_score_id_files {
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/primed-pgs-queries:0.4.0"
+        docker: "uwgac/primed-pgs-queries:0.4.1"
     }
 }
 
@@ -99,7 +99,7 @@ task combine_score_files {
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/primed-pgs-queries:0.4.0"
+        docker: "uwgac/primed-pgs-queries:0.4.1"
         memory: "16 G"
     }
 }
@@ -134,7 +134,7 @@ task calculate_overlap {
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/primed-pgs-queries:0.4.0"
+        docker: "uwgac/primed-pgs-queries:0.4.1"
         memory: mem_gb + " GB"
     }
 }
@@ -153,7 +153,7 @@ task combine_overlap_files {
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/primed-pgs-queries:0.4.0"
+        docker: "uwgac/primed-pgs-queries:0.4.1"
     }
 }
 
@@ -170,6 +170,6 @@ task render_overlap_report {
     }
     runtime {
         # Pull from DockerHub
-        docker: "uwgac/primed-pgs-queries:0.4.0"
+        docker: "uwgac/primed-pgs-queries:0.4.1"
     }
 }

--- a/pgs_variant_overlap/calculate_overlap.Rmd
+++ b/pgs_variant_overlap/calculate_overlap.Rmd
@@ -64,15 +64,22 @@ score_summary <- combined_scores %>%
     group_by(accession, chr_name) %>%
     count(name="n_variants")
 
-overlap_fraction_by_chr <-
-    matches %>%
+match_summary <- matches %>%
     group_by(accession, chr_name) %>%
-    summarise(
-        n_matched=n()
+    count(name="n_matched")
+
+overlap_fraction_by_chr <-
+    score_summary %>%
+    left_join(
+        match_summary,
+        by=c("accession", "chr_name")
     ) %>%
-    left_join(score_summary, by=c("accession", "chr_name")) %>%
     mutate(
+        # Replace NAs with 0
+        n_matched = coalesce(n_matched, 0),
+        # Calculate overlap fraction
         overlap_fraction=n_matched / n_variants,
+        # Make the accession easier to read.
         accession = str_replace(accession, "_hmPOS_GRCh38", "")
     )
 ```


### PR DESCRIPTION
When there were no matches on a chromosome, the score variants would not be included in the total `n_variants` reported by the workflow. Fix this bug by updating the Rmd to properly calculate n_variants.