### PR TITLE
Pin pgscatalog-utils version to working version

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -3,4 +3,4 @@ pandas  # dataframes
 papermill  # parameters in python quarto files
 progressbar2  # pretty progress bar
 requests  # api calls
-pgscatalog-utils  # utilities for working with the PGS catalog
+pgscatalog-utils==1.3.1  # utilities for working with the PGS catalog


### PR DESCRIPTION
The new version of pgscatalog-utils (1.4.1) is throwing new warnings for some scores when running `pgscatalog-combine`, and isn't creating an output file. I've opened a github issue but until it is resolved, pin the pgscatalog-utils version in the requirements file. Link to github issue: https://github.com/PGScatalog/pygscatalog/issues/55