### PR TITLE
Workflow and script to filter PGSCatalog scores

### DIFF
--- a/.dockstore.yml
+++ b/.dockstore.yml
@@ -6,3 +6,7 @@ workflows:
     - name: pgs_variant_overlap
       subclass: WDL
       primaryDescriptorPath: /pgs_variant_overlap.wdl
+    - name: filter_pgs_catalog_scores
+      subclass: WDL
+      primaryDescriptorPath: /filter_pgs_catalog_scores.wdl
+      testParameterFile: /filter_pgs_catalog_scores.json

--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,5 @@ cython_debug/
 
 # Other
 tmp*
+cromwell-*
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
-FROM us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.18.0
+FROM us.gcr.io/broad-dsp-gcr-public/anvil-rstudio-bioconductor:3.20.0
 
 # Check out repository files.
 RUN cd /usr/local && \
     git clone https://github.com/UW-GAC/primed-pgs-queries.git
+
+# Set PYTHONPATH so python can find the pgs_catalog_client package, since it's not released on pip.
+ENV PYTHONPATH="$PYTHONPATH:/usr/local/primed-pgs-queries"
 
 # Install the .in file so we don't overwrite package versions that are in this docker image.
 # Is this a good idea?

--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ To calculate overlap for a set of scores:
 A [WDL workflow](https://dockstore.org/workflows/github.com/UW-GAC/primed-pgs-queries/pgs_variant_overlap:variant-overlap?tab=info) is also provided on Dockstore and as a .WDL file.
 
 
+### Search PGS catalog scores for specific traits and filter by cohort
+
+The `filter_pgs_catalog_scores` directory contains code to search the PGS catalog for scores associated with specific traits and optionally filter the scores by cohort.
+
+To run the filtering script, you can use the following command:
+
+```bash
+python3 filter_pgs_catalog_scores.py --trait-ids MONDO_0005148 --outdir test_output
+```
+
+If you would like to filter the scores to those for which a specific cohort was not used in development,  you can use the `--remove` argument to specify a cohort to use for filtering scores.
+To remove multiple cohorts, you can use the `--remove` argument multiple times, each with a different cohort name.
+For example, to remove scores from the GERA and RPGEH cohorts, you can use the following command:
+
+```bash
+python3 filter_pgs_catalog_scores.py --trait-ids MONDO_0005148 --remove GERA --remove RPGEH --remove RPEGH --outdir test_output
+```
+The script will output three files in the specified output directory (`--outdir`):
+- `all_score_records_for_trait.json`: A list of all PGS scores associated with the specified trait(s).
+- `filtered_score_ids.txt`: A list of PGS score IDs for the trait. If `--remove` was specified, these are the scores that do not include the specified cohort(s) in development.
+- `cohort_records.json`: A list of records for the specified cohort(s), if any were provided via the `--remove` argument.
+
+
+A [WDL workflow](https://dockstore.org/workflows/github.com/UW-GAC/primed-pgs-queries/filter_pgs_catalog_scores:feature/filter-scores?tab=info) is also provided on Dockstore and as a .WDL file in this repository.
+
+
 ## Developer info
 
 ### Generating the API client

--- a/filter_pgs_catalog_scores.wdl
+++ b/filter_pgs_catalog_scores.wdl
@@ -1,0 +1,54 @@
+version 1.0
+
+workflow filter_pgs_catalog_scores {
+
+    input {
+        Array[String] trait_ids
+        Array[String] cohort_short_names = []
+    }
+
+    call filter_scores {
+        input:
+            trait_ids=trait_ids,
+            cohort_short_names=cohort_short_names
+    }
+
+    output {
+        File all_score_records_file = filter_scores.all_score_records_file
+        File? cohort_records_file = filter_scores.cohort_records_file
+        File filtered_score_id_file = filter_scores.filtered_score_id_file
+    }
+    meta {
+        author: "Adrienne Stilp"
+        email: "amstilp@uw.edu"
+    }
+
+}
+
+
+task filter_scores {
+    input {
+        Array[String] trait_ids
+        Array[String] cohort_short_names = []
+    }
+
+    Array[String] trait_param = prefix("--trait-id ", trait_ids)
+    Array[String] remove_param = prefix("--remove ", cohort_short_names)
+
+    command <<<
+        python3 /usr/local/primed-pgs-queries/filter_pgs_catalog_scores/filter_pgs_catalog_scores.py \
+            ~{sep=" " trait_param} \
+            ~{sep=" " remove_param} \
+            --outdir "output"
+
+        >>>
+    output {
+        File all_score_records_file = "output/all_score_records_for_trait.json"
+        File? cohort_records_file = "output/cohort_records.json"
+        File filtered_score_id_file = "output/filtered_score_ids.txt"
+    }
+    runtime {
+        # Pull from DockerHub
+        docker: "uwgac/primed-pgs-queries:0.5.0"
+    }
+}

--- a/filter_pgs_catalog_scores/filter_pgs_catalog_scores.py
+++ b/filter_pgs_catalog_scores/filter_pgs_catalog_scores.py
@@ -1,0 +1,204 @@
+"""Search PGS catalog scores by trait, optionally filter out scores associated with a given cohort, and output results files."""
+
+import argparse
+import json
+import os
+
+import pgs_catalog_client
+
+
+def write_to_json(results, filename):
+    """Write out the results to a JSON file.
+
+    Args:
+        results: A list of model instances from pgs_catalog_client.
+        filename: The output filename to write the JSON to.
+
+    Note:
+        You can recreate the model instance with Model(**record.to_dict())
+        eg: Score(**score.to_dict())
+    """
+
+    with open(filename, "w") as f:
+        f.write(json.dumps([x.to_dict() for x in results], default=str, indent=2))
+
+
+def write_filtered_score_ids(filtered_score_records, filename):
+    """Write out the list of filtered score IDs to a text file.
+
+    Args:
+        filtered_score_records: List of score records (instances of Score model).
+        filename: The output filename to write the score IDs to.
+
+    Note:
+        Each score ID will be written on a new line.
+    """
+    with open(filename, "w") as f:
+        for score in filtered_score_records:
+            f.write(f"{score.id}\n")
+
+
+def search_scores_by_trait(trait_ids, verbose=True):
+    """Search PGS catalog scores by trait_id (ontology ID, e.g., MONDO_0005148).
+
+    Args:
+        trait_ids: A list of ontology IDs to search for. This should be the ontology ID used in the PGS catalog.
+        verbose: If True, print out the number of scores found.
+
+    Returns:
+        List of score records (instances of Score model) that are associated with one of the specified trait_ids.
+
+    Note:
+        See https://ftp.ebi.ac.uk/pub/databases/spot/pgs/metadata/pgs_all_metadata_efo_traits.csv for a list of valid trait IDs.
+    """
+    if verbose:
+        print("Searching for scores associated with traits..")
+
+    # Create an instance of the API class.
+    api_instance = pgs_catalog_client.ScoreEndpointsApi()
+
+    all_results = []
+    for trait_id in trait_ids:
+        # Search scores by ontology ID
+        api_response = api_instance.search_scores(trait_id=trait_id)
+
+        if len(api_response.results) == 0:
+            raise ValueError(f"No scores found for trait_id: {trait_id}")
+
+        if verbose:
+            print("- Number of scores identified for {}: {}".format(trait_id, len(api_response.results)))
+
+        all_results = all_results + api_response.results
+
+    return all_results
+
+
+def get_cohort_records(cohort_short_names, verbose=True):
+    """Get the record for cohorts, which includes scores associated with that cohort.
+
+    Args:
+        cohort_short_names: A list of short name for the cohorts to retrieve, as used by the PGS Catalog.
+        verbose: If True, print out the name (short and full) of the cohort retrieved.
+
+    Returns:
+        A list of cohort records for the specified cohort(s).
+
+    Note:
+        See https://ftp.ebi.ac.uk/pub/databases/spot/pgs/metadata/pgs_all_metadata_cohorts.csv for a list of cohorts in the PGS catalog.
+    """
+    if verbose:
+        print("Retrieving cohort records...")
+
+    api_instance = pgs_catalog_client.SampleEndpointsApi()
+    cohort_records = []
+    for cohort_short_name in cohort_short_names:
+        api_response = api_instance.get_cohorts(cohort_short_name)
+
+        if len(api_response.results) == 0:
+            raise ValueError(f"No cohort found with short name: {cohort_short_name}")
+
+        # Make sure it has only returned one record. It should, but just in case.
+        assert len(api_response.results) == 1, "Expected exactly one cohort record."
+
+        record = api_response.results[0]
+        if verbose:
+            print("- Retrieved cohort record for: {} ({})".format(record.name_short, record.name_full))
+        cohort_records.append(record)
+
+    return cohort_records
+
+
+def remove_score_records_for_cohorts(score_records, cohort_records, development=True, evaluation=False, verbose=True):
+    """Remove score records that are associated with a given cohort.
+
+    Args:
+        score_records: List of score records (instances of Score model).
+        cohort_records: List of cohort records (instances of Cohort model).
+        development: If True, remove scores associated with the cohort's development set.
+        evaluation: If True, remove scores associated with the cohort's evaluation set.
+        verbose: If True, print out the number of scores removed and remaining.
+
+    Returns:
+        List of score records (instances of Score model) filtered to those not associated with one of the cohorts.
+    """
+
+    print("Removing scores associated with cohorts...")
+    scores_to_remove = set()
+    for cohort_record in cohort_records:
+        # Get the score IDs to remove.
+        cohort_score_ids = []
+        if development:
+            cohort_score_ids += [x.id for x in score_records if x.id in cohort_record.associated_pgs_ids.development]
+        if evaluation:
+            cohort_score_ids += [x.id for x in score_records if x.id in cohort_record.associated_pgs_ids.evaluation]
+
+        print(
+            "- Number of scores associated with cohort {}: {}".format(
+                cohort_record.name_short,
+                len(cohort_score_ids),
+            )
+        )
+        scores_to_remove.update(cohort_score_ids)
+
+    # Filter out the score records.
+    filtered_score_records = [score for score in score_records if score.id not in scores_to_remove]
+
+    if verbose:
+        print("- Removed {} score(s) associated with cohorts".format(len(scores_to_remove)))
+        print("- Scores remaining: {}".format(len(filtered_score_records)))
+
+    return filtered_score_records
+
+
+if __name__ == "__main__":
+    # Parse arguments.
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--trait-id",
+        type=str,
+        nargs="+",
+        action="extend",
+        required=True,
+        help="trait_id (as defined by PGS catalog) to search for. Example: MONDO_0005148",
+    )
+    parser.add_argument(
+        "--remove",
+        type=str,
+        action="extend",
+        nargs="+",
+        required=False,
+        help="Cohort short name (as defined by PGS catalog) that should be used to remove scores. Example: GERA",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=str,
+        required=False,
+        help="Output directory to write results to. Default: current directory",
+        default=".",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="If set, suppress verbose output.",
+        default=False,
+    )
+    args = parser.parse_args()
+
+    verbose = not args.quiet
+
+    score_records = search_scores_by_trait(args.trait_id, verbose=verbose)
+    if args.remove:
+        cohort_records = get_cohort_records(args.remove, verbose=verbose)
+        filtered_records = remove_score_records_for_cohorts(score_records, cohort_records, verbose=verbose)
+    else:
+        filtered_records = score_records
+
+    # Write results out to a JSON file.
+    os.makedirs(args.outdir, exist_ok=True)
+    if verbose:
+        print(f"Writing results to directory: {args.outdir}")
+    write_to_json(score_records, os.path.join(args.outdir, "all_score_records_for_trait.json"))
+    if args.remove:
+        write_to_json(cohort_records, os.path.join(args.outdir, "cohort_records.json"))
+    # Write out the list of scores.
+    write_filtered_score_ids(filtered_records, os.path.join(args.outdir, "filtered_score_ids_for_trait.txt"))

--- a/filter_pgs_catalog_scores/filter_pgs_catalog_scores.py
+++ b/filter_pgs_catalog_scores/filter_pgs_catalog_scores.py
@@ -217,4 +217,4 @@ if __name__ == "__main__":
     if args.remove:
         write_to_json(cohort_records, os.path.join(args.outdir, "cohort_records.json"))
     # Write out the list of scores.
-    write_filtered_score_ids(filtered_records, os.path.join(args.outdir, "filtered_score_ids_for_trait.txt"))
+    write_filtered_score_ids(filtered_records, os.path.join(args.outdir, "filtered_score_ids.txt"))


### PR DESCRIPTION
This allows filtering PGSCatalog scores:
- only those associated with a given trait or traits
- remove scores associated with a set of cohorts